### PR TITLE
pass err as argument

### DIFF
--- a/index.js
+++ b/index.js
@@ -28,7 +28,7 @@ class SyslogServer extends EventEmitter {
                 });
 
                 // Socket error handler
-                server.on("error", () => {
+                server.on("error", (err) => {
                     this.emit("error", err);
                 });
 


### PR DESCRIPTION
Resolves below error: 
```
❯ node index.js                                                                                                                                                                                                                                                      
.../syslogserver/node_modules/syslog-server/index.js:32
                    this.emit("error", err);
                                       ^

ReferenceError: err is not defined
    at Socket.server.on (.../node_modules/syslog-server/index.js:32:40)
    at emitOne (events.js:115:13)
    at Socket.emit (events.js:210:7)
    at _handle.lookup (dgram.js:243:14)
    at _combinedTickCallback (internal/process/next_tick.js:105:11)
    at process._tickCallback (internal/process/next_tick.js:161:9)
    at Function.Module.runMain (module.js:607:11)
    at startup (bootstrap_node.js:158:16)
    at bootstrap_node.js:575:3
```
