### PR TITLE
Allows multiple instances to run concurrently

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,37 +3,36 @@
 const dgram = require("dgram");
 const EventEmitter = require("events");
 
-let server;
-let status = false;
-
 class SyslogServer extends EventEmitter {
 
     constructor() {
         super();
+        this.server = null;
+        this.status = false;
     }
 
     start(options = { port: 514, address: "0.0.0.0", exclusive: true }, cb) {
         return new Promise((resolve, reject) => {
-            if (status === true) {
+            if (this.status === true) {
                 let errorObj = createErrorObject(null, "NodeJS Syslog Server is already running!");
                 if (cb) return cb(errorObj);
                 return reject(errorObj);
             } else {
-                server = dgram.createSocket("udp4");
+                this.server = dgram.createSocket("udp4");
 
                 // Socket listening handler
-                server.on("listening", () => {
-                    status = true;
+                this.server.on("listening", () => {
+                    this.status = true;
                     this.emit("start");
                 });
 
                 // Socket error handler
-                server.on("error", (err) => {
+                this.server.on("error", (err) => {
                     this.emit("error", err);
                 });
 
                 // Socket message handler
-                server.on("message", (msg, remote) => {
+                this.server.on("message", (msg, remote) => {
                     let message = {
 						date: new Date(),
                         host: remote.address,
@@ -44,12 +43,12 @@ class SyslogServer extends EventEmitter {
                 });
 
                 // Socket close handler
-                server.on("close", () => {
-                    status = false;
+                this.server.on("close", () => {
+                    this.status = false;
                     this.emit("stop");
                 });
 
-                server.bind(options, (err) => {
+                this.server.bind(options, (err) => {
                     if (err) {
                         let errorObj = createErrorObject(err, "NodeJS Syslog Server failed to start!");
                         if (cb) return cb(errorObj);
@@ -66,7 +65,7 @@ class SyslogServer extends EventEmitter {
     stop(cb) {
         return new Promise((resolve, reject) => {
             try {
-                server.close(() => {
+                this.server.close(() => {
                     if (cb) return cb();
                     return resolve();
                 });
@@ -79,7 +78,7 @@ class SyslogServer extends EventEmitter {
     }
 
     isRunning() {
-        return status;
+        return this.status;
     }
 }
 


### PR DESCRIPTION
The following script demonstrates unexpected behaviour, IMHO.

```node
const a = new SyslogServer({ port: 514 })
const b = new SyslogServer({ port: 515 })
await a.start()
a.isRunning() // true
b.isRunning() // true, should be false
```

The commit 268d270 fixes the issue.