### PR TITLE
Use member variables, provide server instance to callbacks / event handlers.

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,7 +7,7 @@ class SyslogServer extends EventEmitter {
 
     constructor() {
         super();
-        this.server = null;
+        this.socket = null;
     }
 
     start(options = { port: 514, address: "0.0.0.0", exclusive: true }, cb) {
@@ -17,20 +17,20 @@ class SyslogServer extends EventEmitter {
                 if (cb) return cb(errorObj, this);
                 return reject(errorObj);
             } else {
-                this.server = dgram.createSocket("udp4");
+                this.socket = dgram.createSocket("udp4");
 
                 // Socket listening handler
-                this.server.on("listening", () => {
+                this.socket.on("listening", () => {
                     this.emit("start", this);
                 });
 
                 // Socket error handler
-                this.server.on("error", (err) => {
+                this.socket.on("error", (err) => {
                     this.emit("error", err);
                 });
 
                 // Socket message handler
-                this.server.on("message", (msg, remote) => {
+                this.socket.on("message", (msg, remote) => {
                     let message = {
 						date: new Date(),
                         host: remote.address,
@@ -41,11 +41,11 @@ class SyslogServer extends EventEmitter {
                 });
 
                 // Socket close handler
-                this.server.on("close", () => {
+                this.socket.on("close", () => {
                     this.emit("stop");
                 });
 
-                this.server.bind(options, (err) => {
+                this.socket.bind(options, (err) => {
                     if (err) {
                         let errorObj = createErrorObject(err, "NodeJS Syslog Server failed to start!");
                         if (cb) return cb(errorObj, this);
@@ -62,8 +62,8 @@ class SyslogServer extends EventEmitter {
     stop(cb) {
         return new Promise((resolve, reject) => {
             try {
-                this.server.close(() => {
-                    this.server = null;
+                this.socket.close(() => {
+                    this.socket = null;
                     if (cb) return cb(null, this);
                     return resolve(this);
                 });
@@ -76,7 +76,7 @@ class SyslogServer extends EventEmitter {
     }
 
     isRunning() {
-        return (this.server !== null);
+        return (this.socket !== null);
     }
 }
 

--- a/index.js
+++ b/index.js
@@ -14,14 +14,16 @@ class SyslogServer extends EventEmitter {
         return new Promise((resolve, reject) => {
             if (this.isRunning()) {
                 let errorObj = createErrorObject(null, "NodeJS Syslog Server is already running!");
-                if (cb) return cb(errorObj, this);
-                return reject(errorObj);
+                if (cb) cb(errorObj, this);
+                reject(errorObj);
             } else {
                 this.socket = dgram.createSocket("udp4");
 
                 // Socket listening handler
                 this.socket.on("listening", () => {
                     this.emit("start", this);
+                    if(cb) cb(null, this);
+                    resolve(this);
                 });
 
                 // Socket error handler
@@ -50,9 +52,6 @@ class SyslogServer extends EventEmitter {
                         let errorObj = createErrorObject(err, "NodeJS Syslog Server failed to start!");
                         if (cb) return cb(errorObj, this);
                         return reject(errorObj);
-                    } else {
-                        if(cb) return cb(null, this);
-                        return resolve(this);
                     }
                 });
             }

--- a/index.js
+++ b/index.js
@@ -12,7 +12,7 @@ class SyslogServer extends EventEmitter {
 
     start(options = { port: 514, address: "0.0.0.0", exclusive: true }, cb) {
         return new Promise((resolve, reject) => {
-            if (this.server.listening === true) {
+            if (this.isRunning()) {
                 let errorObj = createErrorObject(null, "NodeJS Syslog Server is already running!");
                 if (cb) return cb(errorObj, this);
                 return reject(errorObj);
@@ -63,6 +63,7 @@ class SyslogServer extends EventEmitter {
         return new Promise((resolve, reject) => {
             try {
                 this.server.close(() => {
+                    this.server = null;
                     if (cb) return cb(null, this);
                     return resolve(this);
                 });
@@ -75,7 +76,7 @@ class SyslogServer extends EventEmitter {
     }
 
     isRunning() {
-        return (this.server && this.server.listening);
+        return (this.server !== null);
     }
 }
 

--- a/index.js
+++ b/index.js
@@ -75,7 +75,7 @@ class SyslogServer extends EventEmitter {
     }
 
     isRunning() {
-        return this.server.listening;
+        return (this.server && this.server.listening);
     }
 }
 

--- a/index.js
+++ b/index.js
@@ -14,7 +14,7 @@ class SyslogServer extends EventEmitter {
         return new Promise((resolve, reject) => {
             if (this.server.listening === true) {
                 let errorObj = createErrorObject(null, "NodeJS Syslog Server is already running!");
-                if (cb) return cb(errorObj);
+                if (cb) return cb(errorObj, this);
                 return reject(errorObj);
             } else {
                 this.server = dgram.createSocket("udp4");
@@ -48,11 +48,11 @@ class SyslogServer extends EventEmitter {
                 this.server.bind(options, (err) => {
                     if (err) {
                         let errorObj = createErrorObject(err, "NodeJS Syslog Server failed to start!");
-                        if (cb) return cb(errorObj);
+                        if (cb) return cb(errorObj, this);
                         return reject(errorObj);
                     } else {
-                        if(cb) return cb();
-                        return resolve();
+                        if(cb) return cb(null, this);
+                        return resolve(this);
                     }
                 });
             }
@@ -63,12 +63,12 @@ class SyslogServer extends EventEmitter {
         return new Promise((resolve, reject) => {
             try {
                 this.server.close(() => {
-                    if (cb) return cb();
-                    return resolve();
+                    if (cb) return cb(null, this);
+                    return resolve(this);
                 });
             } catch (err) {
                 let errorObj = createErrorObject(err, "NodeJS Syslog Server is not running!");
-                if (cb) return cb(errorObj);
+                if (cb) return cb(errorObj, this);
                 return reject(errorObj);
             }
         });


### PR DESCRIPTION
Hi, I refactored the syslog server a bit.

 - I moved the global variables into member variables of the class.
 - I pass the server instance via callbacks and event handlers (to give access to the above member variables).
 - I renamed the `server` global variable to `socket` member variable (it is in fact an instance of a `dgram.Socket` class.)